### PR TITLE
NFX-391 custom state with css variable in f-icon

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.10.15] - 2024-09-18
+
+### Patch Changes
+
+- `f-icon` allow custom state with color variable
+
 ## [2.10.14] - 2024-09-18
 
 ### Patch Changes

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonfx/flow-core",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-icon/f-icon.ts
+++ b/packages/flow-core/src/components/f-icon/f-icon.ts
@@ -108,13 +108,15 @@ export class FIcon extends FRoot {
 		if (!this.source) {
 			throw new Error("f-icon : source is mandatory field");
 		}
-		if (
-			this.state?.includes("custom") &&
-			this.fill &&
-			!validateHTMLColor(this.fill) &&
-			!validateHTMLColorName(this.fill)
-		) {
-			throw new Error("f-icon : enter correct color-name or hex-color-code");
+		if (!this.state?.includes("custom, var(")) {
+			if (
+				this.state?.includes("custom") &&
+				this.fill &&
+				!validateHTMLColor(this.fill) &&
+				!validateHTMLColorName(this.fill)
+			) {
+				throw new Error("f-icon : enter correct color-name or hex-color-code");
+			}
 		}
 	}
 


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

# @nonfx/flow-core

## [2.10.15] - 2024-09-18

### Patch Changes

- `f-icon` allow custom state with color variable