### PR TITLE
fix-textarea `f-text-area` keyup events should not bubble up to parent

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.10.19] - 2024-09-26
+
+### Patch Changes
+
+- `f-text-area` keyup events should not bubble up to parent. Fixes f-form-builder from submitting itself when pressing enter.
+
 ## [2.10.18] - 2024-09-26
 
 ### Patch Changes

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonfx/flow-core",
-  "version": "2.10.18",
+  "version": "2.10.19",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-text-area/f-text-area.ts
+++ b/packages/flow-core/src/components/f-text-area/f-text-area.ts
@@ -109,6 +109,11 @@ export class FTextArea extends FRoot {
 		}
 	}
 
+	// We don't want textarea events to bubble up to parent as users can type enters/contrls etc.
+	handleKeyUp(e: KeyboardEvent) {
+		e.stopImmediatePropagation();
+	}
+
 	/**
 	 * emit event
 	 */
@@ -196,6 +201,7 @@ export class FTextArea extends FRoot {
 		this.ariaMultiLine = "true";
 		if (this.placeholder) this.setAttribute("aria-placeholder", this.placeholder);
 	}
+
 	render() {
 		const parentDiv = this.parentElement?.tagName === "F-DIV" ? this.parentElement : "";
 		/**
@@ -256,6 +262,7 @@ export class FTextArea extends FRoot {
 						?mask-value=${this.maskValue}
 						spellcheck=${this.maskValue ? "false" : "true"}
 						@input=${this.handleInput}
+						@keyup=${this.handleKeyUp}
 					></span>
 					${this.clear && Boolean(this.value) && !this.readOnly
 						? html` <f-icon


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

### Add additional question here

- [ ] `Yes`
- [ ] `No`
- [ ] `NA`
