### PR TITLE
NFX-564 f-button and f-icon-button highlight state added

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Change Log
 
+## [3.0.3] - 2024-11-14
+
+### patch changes
+
+- `highlight` state added to `f-button` and `f-icon-button`
+- `f-accordion` chevron direction updated
+
 ## [3.0.2] - 2024-10-23
 
 ### patch changes

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonfx/flow-core",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Core package of flow design system",
   "type": "module",
   "module": "dist/flow-core.es.js",

--- a/packages/flow-core/src/components/f-accordion/f-accordion.scss
+++ b/packages/flow-core/src/components/f-accordion/f-accordion.scss
@@ -10,7 +10,7 @@
 		}
 
 		.f-accordion-icon[data-accordion-open] {
-			transform: rotate(180deg);
+			transform: rotate(90deg);
 			transition: transform var(--transition-time-default) linear;
 		}
 	}

--- a/packages/flow-core/src/components/f-accordion/f-accordion.ts
+++ b/packages/flow-core/src/components/f-accordion/f-accordion.ts
@@ -89,7 +89,7 @@ export class FAccordion extends FRoot {
 		return this.icon === "caret"
 			? "i-caret-down"
 			: this.icon === "chevron"
-			? "i-chevron-down"
+			? "i-chevron-right"
 			: this.open
 			? "i-minus"
 			: "i-plus";

--- a/packages/flow-core/src/components/f-button/f-button.scss
+++ b/packages/flow-core/src/components/f-button/f-button.scss
@@ -31,6 +31,11 @@ $states: (
 		"hover": var(--color-danger-default-hover),
 		"loading": var(--color-danger-surface)
 	),
+	"highlight": (
+		"background": var(--color-highlight-default),
+		"hover": var(--color-highlight-default-hover),
+		"loading": var(--color-highlight-surface)
+	),
 	"inherit": (
 		"background": var(--color-inherit-button),
 		"hover": var(--color-inherit-button-hover),

--- a/packages/flow-core/src/components/f-button/f-button.ts
+++ b/packages/flow-core/src/components/f-button/f-button.ts
@@ -34,6 +34,7 @@ export type FButtonState =
 	| "warning"
 	| "danger"
 	| "inherit"
+	| "highlight"
 	| `custom, ${string}`;
 
 injectCss("f-button", globalStyle);

--- a/packages/flow-core/src/components/f-icon-button/f-icon-button.scss
+++ b/packages/flow-core/src/components/f-icon-button/f-icon-button.scss
@@ -59,6 +59,11 @@ $states: (
 		"hover": var(--color-danger-default-hover),
 		"loading": var(--color-danger-surface)
 	),
+	"highlight": (
+		"background": var(--color-highlight-default),
+		"hover": var(--color-highlight-default-hover),
+		"loading": var(--color-highlight-surface)
+	),
 	"inherit": (
 		"background": var(--color-inherit-button),
 		"hover": var(--color-inherit-button-hover),

--- a/packages/flow-core/src/components/f-icon-button/f-icon-button.ts
+++ b/packages/flow-core/src/components/f-icon-button/f-icon-button.ts
@@ -22,15 +22,16 @@ const variants = ["round", "curved", "block"] as const;
 const categories = ["fill", "outline", "transparent", "packed"] as const;
 const sizes = ["large", "medium", "small", "x-small"] as const;
 
-export type FIconButtonVariant = (typeof variants)[number];
-export type FIconButtonType = (typeof categories)[number];
-export type FIconButtonSize = (typeof sizes)[number];
+export type FIconButtonVariant = typeof variants[number];
+export type FIconButtonType = typeof categories[number];
+export type FIconButtonSize = typeof sizes[number];
 export type FIconButtonState =
 	| "primary"
 	| "danger"
 	| "warning"
 	| "success"
 	| "neutral"
+	| "highlight"
 	| "inherit"
 	| `custom, ${string}`;
 

--- a/packages/flow-core/src/components/f-icon-button/f-icon-button.ts
+++ b/packages/flow-core/src/components/f-icon-button/f-icon-button.ts
@@ -22,9 +22,9 @@ const variants = ["round", "curved", "block"] as const;
 const categories = ["fill", "outline", "transparent", "packed"] as const;
 const sizes = ["large", "medium", "small", "x-small"] as const;
 
-export type FIconButtonVariant = typeof variants[number];
-export type FIconButtonType = typeof categories[number];
-export type FIconButtonSize = typeof sizes[number];
+export type FIconButtonVariant = (typeof variants)[number];
+export type FIconButtonType = (typeof categories)[number];
+export type FIconButtonSize = (typeof sizes)[number];
 export type FIconButtonState =
 	| "primary"
 	| "danger"

--- a/packages/flow-core/src/components/f-icon/f-icon.scss
+++ b/packages/flow-core/src/components/f-icon/f-icon.scss
@@ -31,6 +31,10 @@ $states: (
 		"fill": var(--color-primary-default),
 		"hover-fill": var(--color-primary-default-hover)
 	),
+	"highlight": (
+		"fill": var(--color-highlight-default),
+		"hover-fill": var(--color-highlight-default-hover)
+	),
 	"success": (
 		"fill": var(--color-success-default),
 		"hover-fill": var(--color-success-default-hover)

--- a/stories/flow-core/f-button.stories.ts
+++ b/stories/flow-core/f-button.stories.ts
@@ -84,6 +84,7 @@ export const Playground = {
 				"success",
 				"warning",
 				"danger",
+				"highlight",
 				"inherit",
 				"custom, #0000FF",
 				"custom, gray",
@@ -218,6 +219,11 @@ export const State = {
 				<f-button category="fill" label="inherit" state="inherit"></f-button>
 				<f-button category="outline" label="inherit" state="inherit"></f-button>
 				<f-button category="transparent" label="inherit" state="inherit"></f-button>
+			</f-div>
+			<f-div padding="none" gap="x-large" state="highlight">
+				<f-button category="fill" label="highlight" state="highlight"></f-button>
+				<f-button category="outline" label="highlight" state="highlight"></f-button>
+				<f-button category="transparent" label="highlight" state="highlight"></f-button>
 			</f-div>
 			<f-div padding="none" gap="x-large">
 				<f-button category="fill" label="custom" state="custom, pink"></f-button>

--- a/stories/flow-core/f-icon-button.stories.ts
+++ b/stories/flow-core/f-icon-button.stories.ts
@@ -55,6 +55,7 @@ export const Playground = {
 				"danger",
 				"warning",
 				"neutral",
+				"highlight",
 				"inherit",
 				"custom, #0000FF",
 				"custom, gray",
@@ -189,6 +190,12 @@ export const State = {
 				<f-icon-button icon="i-plus" category="fill" state="danger"></f-icon-button>
 				<f-icon-button icon="i-plus" category="outline" state="danger"></f-icon-button>
 				<f-icon-button icon="i-plus" category="transparent" state="danger"></f-icon-button>
+			</f-div>
+			<f-text variant="para" weight="regular" size="medium">state="highlight"</f-text>
+			<f-div padding="none" gap="x-large">
+				<f-icon-button icon="i-plus" category="fill" state="highlight"></f-icon-button>
+				<f-icon-button icon="i-plus" category="outline" state="highlight"></f-icon-button>
+				<f-icon-button icon="i-plus" category="transparent" state="highlight"></f-icon-button>
 			</f-div>
 			<f-text variant="para" weight="regular" size="medium">state="inherit"</f-text>
 			<f-div padding="none" gap="x-large" state="warning">


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

# @nonfx/flow-core


## [3.0.3] - 2024-11-14

### patch changes

- `highlight` state added to `f-button` and `f-icon-button`
- `f-accordion` chevron direction updated
