### PR TITLE
NFX-701 f-slect options opening direciton fixed

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [3.0.9] - 2024-12-12
+
+### patch changes
+
+- `f-select` options opening direction fixed
+
 ## [3.0.8] - 2024-12-04
 
 ### patch changes

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nonfx/flow-core",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Core package of flow design system",
   "type": "module",
   "module": "dist/flow-core.es.js",

--- a/packages/flow-core/src/components/f-select/f-select.ts
+++ b/packages/flow-core/src/components/f-select/f-select.ts
@@ -375,7 +375,7 @@ export class FSelect extends FRoot {
 			const spaceOnRight =
 				document.body.offsetWidth - this.wrapperElement.getBoundingClientRect().right;
 
-			if (spaceOnRight < this.wrapperElement.offsetWidth) {
+			if (spaceOnRight < this.optionElement.offsetWidth) {
 				right = `right:${spaceOnRight}px;`;
 			}
 		}


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

# @nonfx/flow-core

## [3.0.9] - 2024-12-12

### patch changes

- `f-select` options opening direction fixed
